### PR TITLE
Update Go version recommendation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -81,5 +81,5 @@ updates:
         versions:
           # Ignore updates from series associated with the latest "stable"
           # Go release and no longer supported Go versions.
-          - ">= 1.17"
-          - "< 1.16"
+          - ">= 1.18"
+          - "< 1.17"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ Network Time Protocol (NTP) client for testing purposes.
   - [Overview](#overview)
   - [Changelog](#changelog)
   - [Requirements](#requirements)
-  - [How to install it](#how-to-install-it)
+    - [Building source code](#building-source-code)
+    - [Running](#running)
+  - [Installation](#installation)
+    - [From source](#from-source)
+    - [Using release binaries](#using-release-binaries)
   - [Configuration](#configuration)
     - [Command-line arguments](#command-line-arguments)
   - [Examples](#examples)
@@ -23,9 +27,8 @@ Network Time Protocol (NTP) client for testing purposes.
 
 ## Project home
 
-See [our GitHub repo](https://github.com/atc0005/ntpt) for the latest
-code, to file an issue or submit improvements for review and potential
-inclusion into the project.
+See [our GitHub repo][repo-url] for the latest code, to file an issue or
+submit improvements for review and potential inclusion into the project.
 
 ## Overview
 
@@ -41,24 +44,34 @@ official release is also provided for further review.
 
 ## Requirements
 
-- Go 1.13+ (for building)
+The following is a loose guideline. Other combinations of Go and operating
+systems for building and running tools from this repo may work, but have not
+been tested.
+
+### Building source code
+
+- Go
+  - see this project's `go.mod` file for *preferred* version
+  - this project tests against [officially supported Go
+    releases][go-supported-releases]
+    - the most recent stable release (aka, "stable")
+    - the prior, but still supported release (aka, "oldstable")
 - GCC
   - if building with custom options (as the provided `Makefile` does)
 - `make`
   - if using the provided `Makefile`
 
-Tested using:
+### Running
 
-- Go 1.14+
-- Windows 10 Version 1909
-  - native
-  - WSL
+- Windows 10
 - Ubuntu Linux 18.04+
 
-## How to install it
+## Installation
 
-1. [Download](https://golang.org/dl/) Go
-1. [Install](https://golang.org/doc/install) Go
+### From source
+
+1. [Download][go-docs-download] Go
+1. [Install][go-docs-install] Go
 1. Clone the repo
    1. `cd /tmp`
    1. `git clone https://github.com/atc0005/ntpt`
@@ -82,6 +95,14 @@ Tested using:
 1. Copy the applicable binary to whatever systems needs to run it
    - if using `Makefile`: look in `/tmp/ntpt/release_assets/ntpt/`
    - if using `go build`: look in `/tmp/ntpt/`
+
+### Using release binaries
+
+1. Download the [latest
+   release](https://github.com/atc0005/ntpt/releases/latest) binaries
+1. Deploy
+   - Place `ntpt` in a location of your choice
+     - e.g., `/usr/local/bin/`
 
 ## Configuration
 
@@ -123,3 +144,15 @@ Offset adjusted time: 2020-08-06 04:28:26.977070412 -0500 CDT m=+0.340829713
 ## References
 
 - <https://github.com/beevik/ntp>
+
+<!-- Footnotes here  -->
+
+[repo-url]: <https://github.com/atc0005/ntpt>  "This project's GitHub repo"
+
+[go-docs-download]: <https://golang.org/dl>  "Download Go"
+
+[go-docs-install]: <https://golang.org/doc/install>  "Install Go"
+
+[go-supported-releases]: <https://go.dev/doc/devel/release#policy> "Go Release Policy"
+
+<!-- []: PLACEHOLDER "DESCRIPTION_HERE" -->

--- a/dependabot/docker/go/Dockerfile
+++ b/dependabot/docker/go/Dockerfile
@@ -15,4 +15,4 @@
 # binaries) to reflect that version of Go.
 
 # https://hub.docker.com/_/golang
-FROM golang:1.16.12
+FROM golang:1.17.5

--- a/go.mod
+++ b/go.mod
@@ -7,10 +7,12 @@
 
 module github.com/atc0005/ntpt
 
-go 1.14
+go 1.17
+
+require github.com/beevik/ntp v0.3.0
 
 require (
-	github.com/beevik/ntp v0.3.0
 	github.com/stretchr/testify v1.6.1 // indirect
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381 // indirect
+	golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -17,7 +17,6 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2,13 +2,14 @@
 ## explicit
 github.com/beevik/ntp
 # github.com/stretchr/testify v1.6.1
-## explicit
+## explicit; go 1.13
 # golang.org/x/net v0.0.0-20200707034311-ab3426394381
-## explicit
+## explicit; go 1.11
 golang.org/x/net/bpf
 golang.org/x/net/internal/iana
 golang.org/x/net/internal/socket
 golang.org/x/net/ipv4
 # golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd
+## explicit; go 1.12
 golang.org/x/sys/unix
 golang.org/x/sys/windows


### PR DESCRIPTION
- Update README
  - to direct reader to this project's go.mod file for the preferred
    Go version
  - to use reflinks vs hard-coded values
  - link to official supported Go versions documentation
- Update `go.mod` file to reflect Go 1.17
- Update Dependabot (`dependabot.yml`) configuration to ignore Go
  versions greater than or less than 1.17.x
- Update "canary" Dockerfile to reflect Go 1.17.5, the prior version
  in the 1.17.x series
  - opting to use "one version back" in order to confirm that
    Dependabot picks up the changes as intended
- Run `go mod tidy && go mod vendor`
  - updates format of go.mod to list project dependencies in separate
    direct and transitive require blocks
  - prunes go.mod, go.sum files from vendored dependencies
  - updates format of vendor/modules.txt to note specific version of
    Go used by vendored dependencies

fixes GH-63