### PR TITLE
Exclude local "scratch" directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 # Generated via go build ./cmd/ntpt
 ntpt
 ntpt.exe
+
+# Local temporary/scratch space
+/scratch


### PR DESCRIPTION
Common path that I use for temporary content that I don't intend to commit to version control.