### PR TITLE
Add verbose flag, simplify default output

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Network Time Protocol (NTP) client for testing purposes.
     - [Command-line arguments](#command-line-arguments)
   - [Examples](#examples)
     - [Basic usage](#basic-usage)
+    - [Verbose output](#verbose-output)
   - [References](#references)
 
 ## Project home
@@ -113,32 +114,46 @@ been tested.
 - Flags *not* marked as required are for settings where a useful default is
   already defined.
 
-| Flag          | Required | Default        | Repeat | Possible                                              | Description                                            |
-| ------------- | -------- | -------------- | ------ | ----------------------------------------------------- | ------------------------------------------------------ |
-| `h`, `help`   | No       | `false`        | No     | `h`, `help`                                           | Show Help text along with the list of supported flags. |
-| `s`, `server` | **Yes**  | *empty string* | **No** | *one valid IP Address or fully-qualified server name* | NTP server to submit query against.                    |
+| Flag           | Required | Default        | Repeat | Possible                                              | Description                                             |
+| -------------- | -------- | -------------- | ------ | ----------------------------------------------------- | ------------------------------------------------------- |
+| `h`, `help`    | No       | `false`        | No     | `h`, `help`                                           | Show Help text along with the list of supported flags.  |
+| `s`, `server`  | **Yes**  | *empty string* | **No** | *one valid IP Address or fully-qualified server name* | NTP server to submit query against.                     |
+| `v`, `verbose` | No       | `false`        | **No** | `true`, `false`                                       | Enables display of verbose output. Disabled by default. |
 
 ## Examples
 
 ### Basic usage
 
-```ShellSession
-$ ./ntpt --server ntp.example.com
-Current time from ntp.example.com: 2020-08-06 04:28:26.820043274 -0500 CDT m=+0.183802875
-Response from NTP server "ntp.example.com":
-        Time: 2020-08-06 09:28:26.905991848 +0000 UTC
-        ClockOffset: 31.803212ms
-        RTT: 135.462329ms
-        Stratum: 1
-        ReferenceID: 1196446464
-        ReferenceTime: 2020-08-06 09:28:26.418643103 +0000 UTC
-        RootDelay: 0s
-        RootDispersion: 991.821µs
-        RootDistance: 68.722985ms
+```console
+$ ./ntpt -s pool.ntp.org
+Current time from pool.ntp.org: 2022-08-15 06:16:11.139364388 -0500 CDT m=-0.121229211
+Current time from local system: 2022-08-15 06:16:11.5944353 -0500 CDT m=+0.333841701
+
+The local system is -456.993422ms behind pool.ntp.org.
+```
+
+### Verbose output
+
+```console
+$ ./ntpt -v -s pool.ntp.org
+Current time from pool.ntp.org: 2022-08-15 06:16:41.864305139 -0500 CDT m=-0.193111660
+Current time from local system: 2022-08-15 06:16:42.3228386 -0500 CDT m=+0.265421801
+
+Response from NTP server "pool.ntp.org":
+        Time: 2022-08-15 11:16:41.968756524 +0000 UTC
+        ClockOffset: -459.00146ms
+        RTT: 203.878832ms
+        Stratum: 2
+        ReferenceID: 167864580
+        ReferenceTime: 2022-08-15 11:16:39.020873716 +0000 UTC
+        RootDelay: 213.623µs
+        RootDispersion: 30.518µs
+        RootDistance: 102.076745ms
         Leap: 0
-        MinError: 0s
+        MinError: 357.062044ms
         KissCode: ""
-Offset adjusted time: 2020-08-06 04:28:26.977070412 -0500 CDT m=+0.340829713
+
+Offset adjusted time: 2022-08-15 06:16:42.07080214 -0500 CDT m=+0.013385341
 ```
 
 ## References

--- a/cmd/ntpt/main.go
+++ b/cmd/ntpt/main.go
@@ -24,18 +24,26 @@ var version = "dev build"
 const myAppName string = "ntpt"
 const myAppURL string = "https://github.com/atc0005/" + myAppName
 
+// Default flag settings if not overridden by user input.
 const (
 	// defaultNTPServer is intentionally set to an empty string. Since our
 	// intent is to test a specific server, we don't want to hard-code a
 	// default NTP server.
 	defaultNTPServer string = ""
+
+	defaultVerboseOutput bool = false
 )
 
+// Flag help text (user visible).
 const (
-	// ntpServerFlagHelp is the help text provided to the user for that
-	// flag option
-	ntpServerFlagHelp string = "NTP time server to query"
+	ntpServerFlagHelp     string = "NTP time server to query"
+	verboseOutputFlagHelp string = "Toggles emission of detailed certificate metadata. This level of output is disabled by default."
 )
+
+type config struct {
+	server  string
+	verbose bool
+}
 
 // Branding is responsible for emitting application name, version and origin
 func Branding() {
@@ -67,62 +75,94 @@ func flagsUsage() func() {
 
 func main() {
 
-	var ntpServer string
+	var cfg config
 
-	flag.StringVar(&ntpServer, "server", defaultNTPServer, ntpServerFlagHelp)
-	flag.StringVar(&ntpServer, "s", defaultNTPServer, ntpServerFlagHelp+" (shorthand)")
+	flag.StringVar(&cfg.server, "server", defaultNTPServer, ntpServerFlagHelp)
+	flag.StringVar(&cfg.server, "s", defaultNTPServer, ntpServerFlagHelp+" (shorthand)")
+	flag.BoolVar(&cfg.verbose, "verbose", defaultVerboseOutput, verboseOutputFlagHelp)
+	flag.BoolVar(&cfg.verbose, "v", defaultVerboseOutput, verboseOutputFlagHelp+" (shorthand)")
 	flag.Usage = flagsUsage()
 	flag.Parse()
 
-	if ntpServer == "" {
+	if cfg.server == "" {
 		fmt.Println("NTP server not specified!")
 		flag.Usage()
 		os.Exit(1)
 	}
 
-	ntpServerTime, err := ntp.Time(ntpServer)
+	ntpServerTime, err := ntp.Time(cfg.server)
 	if err != nil {
 		panic(err)
 	}
 
-	fmt.Printf("Current time from %s: %+v\n", ntpServer, ntpServerTime)
+	localTime := time.Now()
+
+	fmt.Printf("Current time from %s: %v\n", cfg.server, ntpServerTime)
+	fmt.Printf("Current time from local system: %v\n", localTime)
 
 	// options := ntp.QueryOptions{Timeout: 30 * time.Second, TTL: 5}
 	// response, err := ntp.QueryWithOptions(ntpServer, options)
-	response, err := ntp.Query(ntpServer)
+	response, err := ntp.Query(cfg.server)
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf(
-		"Response from NTP server %q: \n"+
-			"\tTime: %v\n"+
-			"\tClockOffset: %v\n"+
-			"\tRTT: %v\n"+
-			"\tStratum: %v\n"+
-			"\tReferenceID: %v\n"+
-			"\tReferenceTime: %v\n"+
-			"\tRootDelay: %v\n"+
-			"\tRootDispersion: %v\n"+
-			"\tRootDistance: %v\n"+
-			"\tLeap: %v\n"+
-			"\tMinError: %v\n"+
-			"\tKissCode: %q\n",
-		ntpServer,
-		response.Time,
-		response.ClockOffset,
-		response.RTT,
-		response.Stratum,
-		response.ReferenceID,
-		response.ReferenceTime,
-		response.RootDelay,
-		response.RootDispersion,
-		response.RootDistance,
-		response.Leap,
-		response.MinError,
-		response.KissCode,
-	)
 
-	offsetAdjTime := time.Now().Add(response.ClockOffset)
-	fmt.Println("Offset adjusted time:", offsetAdjTime)
+	// fmt.Printf(
+	// 	"Estimated offset of local client clock relative to %s: %+v\n",
+	// 	cfg.server,
+	// 	response.ClockOffset,
+	// )
+
+	switch {
+	case cfg.verbose:
+		fmt.Printf(
+			"\nResponse from NTP server %q: \n"+
+				"\tTime: %v\n"+
+				"\tClockOffset: %v\n"+
+				"\tRTT: %v\n"+
+				"\tStratum: %v\n"+
+				"\tReferenceID: %v\n"+
+				"\tReferenceTime: %v\n"+
+				"\tRootDelay: %v\n"+
+				"\tRootDispersion: %v\n"+
+				"\tRootDistance: %v\n"+
+				"\tLeap: %v\n"+
+				"\tMinError: %v\n"+
+				"\tKissCode: %q\n",
+			cfg.server,
+			response.Time,
+			response.ClockOffset,
+			response.RTT,
+			response.Stratum,
+			response.ReferenceID,
+			response.ReferenceTime,
+			response.RootDelay,
+			response.RootDispersion,
+			response.RootDistance,
+			response.Leap,
+			response.MinError,
+			response.KissCode,
+		)
+
+		offsetAdjTime := time.Now().Add(response.ClockOffset)
+		fmt.Printf("\nOffset adjusted time: %v\n", offsetAdjTime)
+
+	default:
+
+		timeDirection := "behind"
+		if localTime.Before(ntpServerTime) {
+			timeDirection = "ahead of"
+		}
+
+		// The local system is 2m28.258534398s behind pool.ntp.org.
+		// The local system is 2m28.258534398s ahead of pool.ntp.org.
+		fmt.Printf(
+			"\nThe local system is %v %s %s.\n",
+			response.ClockOffset,
+			timeDirection,
+			cfg.server,
+		)
+
+	}
 
 }

--- a/doc.go
+++ b/doc.go
@@ -20,35 +20,7 @@ FEATURES
 
 USAGE
 
-	$ ./ntpt -h
-
-	ntpt dev build
-	https://github.com/atc0005/ntpt
-
-	Usage of "ntpt":
-	-s string
-			NTP time server to query (shorthand)
-	-server string
-			NTP time server to query
-
-EXAMPLE
-
-	$ ./ntpt --server ntp.example.com
-	Current time from ntp.example.com: 2020-08-06 04:28:26.820043274 -0500 CDT m=+0.183802875
-	Response from NTP server "ntp.example.com":
-			Time: 2020-08-06 09:28:26.905991848 +0000 UTC
-			ClockOffset: 31.803212ms
-			RTT: 135.462329ms
-			Stratum: 1
-			ReferenceID: 1196446464
-			ReferenceTime: 2020-08-06 09:28:26.418643103 +0000 UTC
-			RootDelay: 0s
-			RootDispersion: 991.821µs
-			RootDistance: 68.722985ms
-			Leap: 0
-			MinError: 0s
-			KissCode: ""
-	Offset adjusted time: 2020-08-06 04:28:26.977070412 -0500 CDT m=+0.340829713
+See our main README for supported settings and examples.
 
 */
 package main


### PR DESCRIPTION
- add `-v`, `--verbose` flags
- update README coverage
- use simply config struct to hold CLI flag settings
- simplify default output
- place verbose output behind conditional check

fixes GH-84