### PR TITLE
Update project to Go 1.19

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -81,5 +81,5 @@ updates:
         versions:
           # Ignore updates from series associated with the latest "stable"
           # Go release and no longer supported Go versions.
-          - ">= 1.18"
-          - "< 1.17"
+          - ">= 1.20"
+          - "< 1.19"

--- a/dependabot/docker/go/Dockerfile
+++ b/dependabot/docker/go/Dockerfile
@@ -15,4 +15,4 @@
 # binaries) to reflect that version of Go.
 
 # https://hub.docker.com/_/golang
-FROM golang:1.17.13
+FROM golang:1.19.0

--- a/doc.go
+++ b/doc.go
@@ -1,26 +1,23 @@
 /*
-
 Network Time Protocol (NTP) client for testing purposes.
 
-PROJECT HOME
+# Project Home
 
-See our GitHub repo (https://github.com/atc0005/ntpt) for the latest
-code, to file an issue or submit improvements for review and potential
-inclusion into the project.
+See our GitHub repo (https://github.com/atc0005/ntpt) for the latest code, to
+file an issue or submit improvements for review and potential inclusion into
+the project.
 
-PURPOSE
+# Purpose
 
 Perform a NTP query against a specified server for testing purposes.
 
-FEATURES
+# Features
 
-• single binary, no outside dependencies
+  - single binary, no outside dependencies
+  - query specified NTP server for current time
 
-• query specified NTP server for current time
-
-USAGE
+# Usage
 
 See our main README for supported settings and examples.
-
 */
 package main

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@
 
 module github.com/atc0005/ntpt
 
-go 1.17
+go 1.19
 
 require github.com/beevik/ntp v0.3.0
 


### PR DESCRIPTION
- update go.mod file from Go 1.17 to 1.19
- update doc.go file to use Go 1.19 package doc comments syntax
- update "Canary" Dockerfile to reflect current Go 1.19 version
- update Dependabot configuration for Dockerfile to ignore Go
  releases outside of the Go 1.19 release series