### PR TITLE
Add missing cmd doc file

### DIFF
--- a/cmd/ntpt/doc.go
+++ b/cmd/ntpt/doc.go
@@ -1,0 +1,18 @@
+// Copyright 2020 Adam Chalkley
+//
+// https://github.com/atc0005/ntpt
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+// Perform a NTP query against a specified server for testing purposes.
+//
+// See our [GitHub repo]:
+//
+//   - to review documentation (including examples)
+//   - for the latest code
+//   - to file an issue or submit improvements for review and potential
+//     inclusion into the project
+//
+// [GitHub repo]: https://github.com/atc0005/ntpt
+package main


### PR DESCRIPTION
Add "package" doc file to resolve revive `package-comment`
linting error surfaced by recent linter update.